### PR TITLE
Fix SUPG example for missing mapping correction terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+*/.ipynb_checkpoints

--- a/examples/jupyter/demo011_advection_supg.ipynb
+++ b/examples/jupyter/demo011_advection_supg.ipynb
@@ -10,7 +10,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# dependencies\n",
@@ -51,18 +53,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# setup\n",
     "basis = TensorH1LagrangeBasis(p, q, 1, 1, collocatedquadrature = collocate, mapping = mapping)\n",
+    "Δx = 1.0\n",
     "\n",
     "mesh = []\n",
     "if dimension == 1\n",
-    "   mesh = Mesh1D(1.0)\n",
+    "   mesh = Mesh1D(Δx)\n",
     "elseif dimension == 2\n",
-    "   mesh = Mesh2D(1.0, 1.0)\n",
-    "end"
+    "   mesh = Mesh2D(Δx, Δx)\n",
+    "end\n",
+    "\n",
+    "# Element mappings\n",
+    "dxdξ = Δx / 2 # 2 comes from quadrature domain of [-1,1]\n",
+    "dξdx = 1 / dxdξ\n",
+    "det_dxdξ = dxdξ # Determinant of mapping Jacobian"
    ]
   },
   {
@@ -76,7 +86,8 @@
      21,
      26,
      29
-    ]
+    ],
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -84,7 +95,7 @@
     "function supgadvectionweakform(U::Matrix{Float64}, w::Array{Float64})\n",
     "    u = U[1, :]\n",
     "    du = U[2, :]\n",
-    "    dv = (c * u - c * τ * (c * du)) * w[1]\n",
+    "    dv = dξdx * (c * u - c * τ * (c * du) * dξdx) * w[1] * det_dxdξ\n",
     "    return [dv]\n",
     "end\n",
     "\n",
@@ -102,8 +113,8 @@
     "\n",
     "# SUPG mass weak form and mass operator\n",
     "function supgmassweakform(udot::Array{Float64}, w::Array{Float64})\n",
-    "    v = udot * w[1]\n",
-    "    dv = c * τ * udot * w[1]\n",
+    "    v = udot * w[1] * det_dxdξ\n",
+    "    dv = dξdx * c * τ * udot * w[1] * det_dxdξ\n",
     "    return ([v; dv],)\n",
     "end\n",
     "supgmass = Operator(\n",
@@ -125,14 +136,15 @@
      2,
      10,
      20
-    ]
+    ],
+    "tags": []
    },
    "outputs": [],
    "source": [
     "# compute and plot dispersion and phase speed\n",
     "# -- 1D --\n",
     "function advectionsupgsymbol(θ_range)\n",
-    "    A = computesymbols(supgadvection, [θ_range]) * 2 # transform from reference to physical on dx=1 grid\n",
+    "    A = computesymbols(supgadvection, [θ_range]) # transform from reference to physical on dx=1 grid\n",
     "    M = computesymbols(supgmass, [θ_range]) # mass matrix\n",
     "    return sort(imag.(eigvals(-M \\ A)))\n",
     "end\n",
@@ -165,17 +177,17 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Julia 1.8.5",
+   "display_name": "Julia 1.9.1",
    "language": "julia",
-   "name": "julia-1.8"
+   "name": "julia-1.9"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.8.5"
+   "version": "1.9.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ end
     include("../examples/ex011_advection_supg.jl")
 
     @test min(eigenvalues...) ≈ 0.0000000000000000
-    @test max(eigenvalues...) ≈ 2.0998054953673844
+    @test max(eigenvalues...) ≈ 3.190216788544891
 end
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
SUPG requires different mapping corrections than the Galerkin example. I went ahead and added in all the mapping correction factors, including the ones that cancel each other out.